### PR TITLE
fix: outdated import from typing_extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
         "cfx-address>=1.2.4,<1.3.0",
         "cfx-account>=1.2.2,<1.3.0", 
         "cfx-utils>=1.0.5,<1.2.0",
+        "typing-extensions<=4.13.2",
     ],  # add any additional packages that need to be installed
     # needs to be installed along with your package. Eg: 'caer'
     extras_require=extras_require,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/python-conflux-sdk/68)
<!-- Reviewable:end -->
